### PR TITLE
Remove redundant CI trigger on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, dev]
-  push:
-    branches: [main, dev]
 
 jobs:
   check:


### PR DESCRIPTION
CI only needs to run on PRs, not again after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub Actions triggers; no production code or runtime behavior is affected, with minimal risk beyond reduced coverage for direct pushes.
> 
> **Overview**
> CI is now triggered only for `pull_request` events on `main` and `dev`, removing the redundant `push` trigger so builds don’t run again after merges/direct pushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a05425afad74af6bc016e485470a7a2399f324d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->