### PR TITLE
Move dev tag to top left

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -83,7 +83,7 @@ export default function RootLayout({
         >
           <NavigationProvider>
             {process.env.VERCEL_GIT_COMMIT_REF === "dev" && (
-              <div className="fixed top-2 right-2 z-[100] bg-accent text-white text-xs font-bold px-2 py-1 rounded">
+              <div className="fixed top-2 left-2 z-[100] bg-accent text-white text-xs font-bold px-2 py-1 rounded">
                 dev
               </div>
             )}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a small UI positioning change with no impact to logic, data handling, or security.
> 
> **Overview**
> Moves the `dev` environment badge shown when `VERCEL_GIT_COMMIT_REF === "dev"` from the top-right to the top-left of the viewport in `app/layout.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91f3da3555f759504fe333ae49bb2d8529145c12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->