### PR TITLE
Rewrite home page and normalize page subtitles

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,70 +1,53 @@
-"use client"
-
 import Link from "next/link"
+import ReactMarkdown, { type Components } from "react-markdown"
+import remarkGfm from "remark-gfm"
 import { PageTitle } from "@/components/layout/page-title"
+import { getHomeContent } from "@/lib/home"
 
-function TypographyParagraph({ children }: { children: React.ReactNode }) {
-  return (
-    <> 
-      <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+const markdownComponents: Components = {
+  p: ({ children }) => (
+    <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-6 last:mb-0">
+      {children}
+    </p>
+  ),
+  a: ({ href, children }) => {
+    if (href?.startsWith("/")) {
+      return (
+        <Link
+          href={href}
+          className="text-accent hover:underline underline-offset-4"
+        >
+          {children}
+        </Link>
+      )
+    }
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-accent hover:underline underline-offset-4"
+      >
         {children}
-      </p>
-      <br />
-    </>
-  )
+      </a>
+    )
+  },
+  strong: ({ children }) => (
+    <strong className="text-foreground font-medium">{children}</strong>
+  ),
+  em: ({ children }) => <em className="italic">{children}</em>,
 }
 
 export default function HomePage() {
+  const content = getHomeContent()
+
   return (
     <div className="min-h-[calc(100vh-3.5rem)] flex items-center">
       <div className="container max-w-2xl mx-auto px-6 py-12">
         <PageTitle>jake bodea</PageTitle>
-
-        <TypographyParagraph>
-          resumes are boring, so i made this website to showcase myself. i have a{" "}
-          <Link
-            href="/timeline"
-            className="text-accent hover:underline underline-offset-4"
-          >
-            timeline
-          </Link>{" "}
-          for more details, but i prefer to{" "}
-          <Link
-            href="/projects"
-            className="text-accent hover:underline underline-offset-4"
-          >
-            show
-          </Link>{" "}
-          my accomplishments
-        </TypographyParagraph>
-
-        <TypographyParagraph>
-          i&apos;m an all-around engineer with a math background. i majored in
-          math with minors in cs, business data analytics, and music. currently
-          studying ai at stanford. i love working on product and i like making
-          music
-        </TypographyParagraph>
-        <TypographyParagraph> 
-          my tech stack is pretty much &quot;i&apos;ll learn whatever you need me to learn&quot;, 
-          but i have strong experience with TypeScript, Python, and SQL. also
-          dabbling in Rust :) 
-        </TypographyParagraph>
-        <TypographyParagraph>
-          in my free time, you&apos;ll find me volunteering at church, working on 
-          side projects (technical or musical), or exploring new adventures 
-          with my wife
-        </TypographyParagraph>
-
-        <p className="text-base text-muted-foreground/70 mt-8">
-          thanks for checking out my website, and please please please {" "}
-          <Link
-            href="/contact"
-            className="text-accent hover:underline underline-offset-4"
-          >
-            say hi
-          </Link>
-          {" "}!
-        </p>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {content}
+        </ReactMarkdown>
       </div>
     </div>
   )

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -33,7 +33,7 @@ export default function ContactPage() {
         <PageTitle>contact</PageTitle>
 
         <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-12">
-          i&apos;m always interested in connecting. here&apos;s where you can find me:
+          I&apos;m always interested in connecting. Here&apos;s where you can find me:
         </p>
 
         <div className="rounded-lg border border-accent/10 bg-muted/20 p-4 font-mono text-sm">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function ProjectsPage(): React.ReactNode {
   return (
-    <PageWrapper title="projects" subtitle="a showcase of my technical work.">
+    <PageWrapper title="projects" subtitle="A showcase of my technical work.">
       <div className="space-y-8">
         <Separator />
         <GithubContributions />

--- a/app/quotes/quotes-client.tsx
+++ b/app/quotes/quotes-client.tsx
@@ -160,7 +160,7 @@ export default function QuotesPageClient({ initialQuotes }: QuotesPageProps) {
   }, [searchQuery, baseQuotes])
 
   return (
-    <PageWrapper title="quotes" subtitle="a collection of quotes and sources that have inspired me.">
+    <PageWrapper title="quotes" subtitle="A collection of quotes and sources that have inspired me.">
       <NotionSyncBrag />
       <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="search quotes..." />
 

--- a/components/common/github-calendar.tsx
+++ b/components/common/github-calendar.tsx
@@ -15,8 +15,8 @@ export function GithubContributions() {
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        many of my company projects are under NDA and can&apos;t be shown here,
-        but my github contribution calendar gives an idea of my output.
+        Many of my company projects are under NDA and can&apos;t be shown here,
+        but my GitHub contribution calendar gives an idea of my output.
       </p>
       <a href="https://github.com/jakebodea" target="_blank" rel="noopener noreferrer" className="block overflow-x-auto">
         {mounted && (

--- a/components/common/timeline-wrapper.tsx
+++ b/components/common/timeline-wrapper.tsx
@@ -7,7 +7,7 @@ import { PageWrapper } from "@/components/layout/page-wrapper";
 
 export function TimelineWrapper(): React.ReactNode {
   return (
-    <PageWrapper title="timeline" subtitle="a chronological journey through my career experiences.">
+    <PageWrapper title="timeline" subtitle="A chronological journey through my career experiences.">
       <Timeline items={timelineItems} />
     </PageWrapper>
   );

--- a/content/home.md
+++ b/content/home.md
@@ -1,0 +1,15 @@
+If we were sitting across a table and you asked me to tell you about myself, this is more or less what I'd say:
+
+Hi, I'm Jake. I'm a Romanian-American from Southern California. I studied math in undergrad, with minors in CS, business analytics, and music. Then I went back for a graduate certificate in AI at Stanford, and these days I help teach two of their machine learning courses online (still a little surreal tbh). I bring that up because I know ML deeply: the math, stats and the neural net architecture underneath, etc...  as well as the online buzzwords :)
+
+Right now I'm a "machine learning engineer" at TaxRise, but what I really love is building AI products end to end, and I've gotten to do plenty of that here. I built a fleet of voice AI agents, living in both phone and web apps. I built our [main website](https://taxrise.com), including a [sales chat interface](https://chat.taxrise.com) that funnels leads. I built the document embedding that powers our RAG and classification. Across all of it I get to own the design, the frontend, the model, and the product calls in between, which is exactly how I like to work.
+
+I thrive in areas prioritizing by small teams, fast shipping, and plenty of encouragement to take an idea straight to production. That kind of pace and freedom is the future imo!
+
+Most of my work is in TypeScript, Python, and SQL, and I'm slowly picking up Rust. Honestly though, idrc about the language. Give me something hard in a stack I've never touched and I'll figure it out.
+
+I'm pretty terminally online about all of this. New model releases, AI lab drama, new best practices, whatever paper everyone is arguing about that week... I keep up with it because I genuinely enjoy it. I'm lowkey obsessed, so please bring it up and I'll gladly chop it up with you about any of it haha
+
+Outside of work, I'm a worship leader and youth volunteer at Agape Church, where I serve a few times a week. The rest of my time goes to side projects and chasing adventures with my wife, who somehow puts up with all the late night coding and constant flurry of ideas.
+
+Thanks for checking out my website. Please poke around to see the [work](/projects), the [timeline](/timeline), some [writings](/writings), and a few [quotes](/quotes) I like. But even better, I'd like to meet you! Please [say hi](/contact) :)

--- a/lib/home.ts
+++ b/lib/home.ts
@@ -1,0 +1,7 @@
+import fs from 'fs'
+import path from 'path'
+
+export function getHomeContent(): string {
+  const filePath = path.join(process.cwd(), 'content', 'home.md')
+  return fs.readFileSync(filePath, 'utf8').trim()
+}


### PR DESCRIPTION
## Summary
- Rewrote the home page as an interview-style intro in `content/home.md`, rendered via a server component with markdown links
- Normalized page subtitles and supporting copy to sentence case while keeping lowercase nav/page headers
- Capitalized the GitHub calendar NDA note on the projects page

## Test plan
- [ ] Load `/` and confirm home copy, internal links, and external TaxRise links render correctly
- [ ] Check `/projects`, `/timeline`, `/quotes`, and `/contact` subtitles and intro copy
- [ ] Verify `bun run build` passes